### PR TITLE
New model cherry picked

### DIFF
--- a/docs/GLOSSAIRE.md
+++ b/docs/GLOSSAIRE.md
@@ -1,5 +1,9 @@
 # Glossaire
 
+## modèle de données
+
+Les termes du modèle de données sont décrit dans le [README du dossier specs](../specs/README.md)
+
 ## Hydrater
 
 Processus d'injecter des contenus dans un système pour qu'il ne soit pas vide.

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,7 +12,7 @@ Il y a trois types d'activités : recherche, méthode et pédagogique.
 
 Champs : 
 
-- **type** *mandatory* : trois valeurs possibles : recherche, pédagogie
+- **type** *mandatory* : trois valeurs possibles : recherche, pédagogie, méthode
 - **name** *fr/en*, *mandatory* : nom au sens de acronyme, nom officiel...
 - **baseline** *fr/en*, *mandatory* : phrase courte ou question posant le but de l'activité
 - **description** *fr/en*, *mandatory*: court paragraphe présentant l'activité 
@@ -52,7 +52,7 @@ Champs :
 - **LastName** *mandatory*
 - **membership** : associate, member
 Distinction entre membre et associé.
-- **title** *fr/en*: titre académique/poste occupé
+- **function** *fr/en*: fonction occupée au format libre mais fortement suggéré, convergents vers des appelations communes : Directeur scientifique - Chercheur.e, Directeur technique - Ingénieur.e de recherche, Directeur de FORCCAST, Designer.e de recherche,     Ingénieur.e de recherche, Ingénieur.e pédagogique, Chercheur.e, Chargé.e de communication, Secrétaire général.e,     Assistant.e de recherche
 - **currentStatus** : champs ouvert une ou deux phrases décrivant les sujets de travail actuel
 - **domain** : academic, technic, design, pedagogy, administrative. Utilisé uniquemnt pour du filtrage.
 - **contact** : information de contact, site perso, email... sous la forme de clef/valeur librement défini et pouvant contenir des liens ou emails (dans valeur)
@@ -112,24 +112,26 @@ Liens :
 *en moyenne 2-3, max 5, régulièrement 0*
 
 
-## Publication
+## Production
 
 Label :
 
-- en : papers and tools 
-- fr : publis et outils
+- en : Productions 
+- fr : Productions
 
 Champs : 
 
-- **type** *enum* : article/article, conférence/conference, livre/book, web/web, logiciel/software, exposition/exhibition, manuscript/working paper, corpus/dataset
-- **title** *fr/en*, *mandatory* : titre de la publication
+- **type** *enum* : article/article, communication/communication, livre/book, working paper/working paper, datascape/datascape, site web/website, logiciel/software, code/code, exposition/exhibition, atelier/workshop, simulation/simulation, conférence/conference
+- **title** *fr/en*, *mandatory* : titre de la production
 - **description** *fr/en* : présentation courte en une phrase ou deux rédigée par l'équipe éditoriale
 - **content** *fr/en* : contenu en markdown qui ne contient en général pas le contenu de la publication en entier mais son abstract
 - **date** : date de publication
+- **URL** : URL vers le plein texte, le site, l'outil, github, site de l'éditeur ou SPIRE... (rempli automatiquement si publi récupérée dans Spire)
 - **spireJson** : métadonnées complètes de la publication provenant de la plateforme biblio de Science Po
-- **authors** : liste des auteurs (rempli automatiquement si publi récupérée dans Spire)
-- **biblioRef** : référence biblio pour citer cette publication (rempli automatiquement si publi récupérée dans Spire)
-- **fullTextURL** : URL vers le plein texte, site de l'éditeur ou SPIRE... (rempli automatiquement si publi récupérée dans Spire)
+- **authors** : liste des auteurs au format texte (rempli automatiquement si publi récupérée dans Spire)
+- **biblioRef** : référence biblio pour citer cette publication (rempli automatiquement si publi récupérée dans Spire, sera régulièrement vide pour les productions hors publi)
+- **illustration** : assurée pour les cas datascape, siteweb, logiciel, exposition, atelier, simulation mais plutôt pas pour les autres.
+- **active** : certains outils sont dépréciés ce serait important d'indiquer cela.
 
 Liens : 
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -16,18 +16,27 @@ Champs :
 - **name** *fr/en*, *mandatory* : nom au sens de acronyme, nom officiel...
 - **baseline** *fr/en*, *mandatory* : phrase courte ou question posant le but de l'activité
 - **description** *fr/en*, *mandatory*: court paragraphe présentant l'activité 
+- **illustration** : image d'illustration + sa version traité par le filtre graphique
 - **content** *fr/en*: le contenu riche (markdown) décrivant l'activité
+- **documentation** : annexes, liste de média associés (document PDF, site web annexe, )
 - **important** : boolean qui indique si l'activité est structurante. Ces activités sont par défaut mises en haut de liste. 
 - **active** : boolean qui indique si l'activité est active ou passée
+---
+## /!\ A discuter
 
+- **documents** : documents associés ?
+- dates ?
+---
 Liens :
 
 - **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. on ne liste pas toutes les personnes participants ponctuellement.  
 *En moyenne 2-3, minimum 1, max 10 personnes*
+- **Activités -> Activités** : activités qui sont proches, prolongation d'un projet par un autre, proximité thématique ou méthodo forte...  
+*En moyenne 2, max 4, souvent 0*
 - **Publication -> Activités** : activités qui ont suscité cette publication.  
-*En moyenne 1 ou 2, max 10, régulièrement 0*
+*En moyenne 1 ou 2, max 10, souvent 0*
 - **Actualités -> Activités** : actualités à propos de cette activité.  
-*en moyenne 3, max 10, régulièrement 0*
+*en moyenne 3, max 10, souvent 0*
 
 
 ## People
@@ -37,8 +46,44 @@ label :
 - fr: Équipe
 - en: Team
 
+Les membres du médialab présents et passés. Toutes les personnes travaillant au médialab ou étant associé.
+25 personnes environ présentes mais l'effectifs devraient monter les prochaines années vers 35. L'historique représentent environ le double. 
+
+
+Champs :
+- **FirstName** *mandatory*
+- **LastName** *mandatory*
+- **gender** : male, female.  
+Pour faire des générations de nom prenant en compte l'info notamment pour associé.e
+- **membership** : associate, member
+Distinction entre membre et associé.
+- **title** *fr/en*: titre académique/poste occupé
+- **contact** : information de contact, site perso, email... (on détecte les liens dans le template ?)
+- **bio** *fr/en*: contenu markdown
+- **active** : boolean indiquant si la personne est présentemment dans l'équipe
+- **picture** : photo (non traitée graphiquement ? en N&B)
+
+---
+## /!\ A discuter
+
+- **documentation** : documents associés genre pour un CV perso, site perso... ?
+---
+
+Liens :
+
+- **Activités -> People** : Activités de la personne.  
+*En moyenne 3-4, minimum 1, max 10 activités*
+- **Publications -> People** : publications de la personne.  
+*En moyenne 8, max 30, minimum 0 possible*
+- **Actualités -> People** : actualités à propos de cette personne.  
+*en moyenne 3-4, max 20, régulièrement 0*
+
+Liens sélectionnés :
+
+On aimerait pouvoir mette en avant certains objets liés dans les activités et les publications. Sélectionner des 5 (?) plus importants par l'utilisateur pour les cas où il y a une longue liste.
 
 ## Actualité
+
 ## Publication
 
 papers and tools 

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,7 +12,7 @@ Il y a trois types d'activités : recherche, méthode et pédagogique.
 
 Champs : 
 
-- **type** *mandatory* : trois valeurs possibles : recherche, méthode, pédagogie
+- **type** *mandatory* : trois valeurs possibles : recherche, pédagogie
 - **name** *fr/en*, *mandatory* : nom au sens de acronyme, nom officiel...
 - **baseline** *fr/en*, *mandatory* : phrase courte ou question posant le but de l'activité
 - **description** *fr/en*, *mandatory*: court paragraphe présentant l'activité 
@@ -21,14 +21,14 @@ Champs :
 - **documentation** : annexes, liste de média associés (document PDF, site web annexe, )
 - **important** : boolean qui indique si l'activité est structurante. Ces activités sont par défaut mises en haut de liste. 
 - **active** : boolean qui indique si l'activité est active ou passée
-- **startDate** : date indiquée dans la page activité
-- **endDate** : date indiquée dans la page activité 
+- **startDate** : date précise au mois uniquement indiquée dans la page activité
+- **endDate** : date précise au mois indiquée dans la page activité 
 
 Liens :
 
-- **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. On ne liste pas toutes les personnes participants ponctuellement.  
-*En moyenne 2-3, minimum 1, max 10 personnes*
-- **Activités -> Activités** : activités qui sont proches, prolongation d'un projet par un autre, proximité thématique ou méthodo forte...  
+- **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. On ne liste pas toutes les personnes participant ponctuellement. Distinguer les liens vers des personnes actives des personnes parties. 
+*En moyenne 2-3, minimum 1, max 10 personnes actives (le double en comptant les personnes parties)*
+- **Activités -> Activités** : activités qui sont proches, prolongation d'un projet par un autre, proximité thématique ou méthodo forte... Distinguer les activités actives et passives (ne change pas la cardinalité)  
 *En moyenne 2, max 4, souvent 0*
 - **Publication -> Activités** : activités qui ont suscité cette publication.  
 *En moyenne 1 ou 2, max 10, souvent 0*
@@ -53,9 +53,9 @@ Champs :
 - **membership** : associate, member
 Distinction entre membre et associé.
 - **title** *fr/en*: titre académique/poste occupé
-- **description** : champs ouvert paragraphe
-- **domaine** : champs fermé
-- **contact** : information de contact, site perso, email... (on détecte les liens dans le template ?)
+- **currentStatus** : champs ouvert une ou deux phrases décrivant les sujets de travail actuel
+- **domain** : academic, technic, design, pedagogy, administrative. Utilisé uniquemnt pour du filtrage.
+- **contact** : information de contact, site perso, email... sous la forme de clef/valeur librement défini et pouvant contenir des liens ou emails (dans valeur)
 - **bio** *fr/en*: contenu markdown
 - **active** : boolean indiquant si la personne est présentemment dans l'équipe
 - **picture** : photo (non traitée graphiquement ? en N&B)
@@ -63,8 +63,8 @@ Distinction entre membre et associé.
 
 Liens :
 
-- **Activités -> People** : Activités de la personne.  
-*En moyenne 3-4, minimum 1, max 10 activités*
+- **Activités -> People** : Activités de la personne. Attention les activités pouvant être non-active, il faudrait les distinguer dans les liens. 
+*En moyenne 3-4, minimum 1, max 10 activités actives*
 - **Publications -> People** : publications de la personne.  
 *En moyenne 8, max 30, minimum 0 possible*
 - **Actualités -> People** : actualités à propos de cette personne.  
@@ -73,6 +73,11 @@ Liens :
 Liens sélectionnés :
 
 On aimerait pouvoir mette en avant certains objets liés dans les activités et les publications. Sélectionner des 5 (?) plus importants par l'utilisateur pour les cas où il y a une longue liste.
+
+- **People -> Activités principales** : Sélection des max 5 principales activités de la personne. Pas de disticntion actif/passé car sélectionné par l'utilisateur.  
+*En moyenne 2, minimum 1, max 5 activités*
+- **People -> Publications principales** : Sélectiondes max 5 principales publications de la personne.  
+*En moyenne 2, max 5, minimum 0 possible*
 
 ## News
 
@@ -99,11 +104,11 @@ champs :
 
 Liens :
 
-- **Actualités -> Activités** : Activités en lien avec l'actualité  
+- **Actualités -> Activités** : Activités en lien avec l'actualité. Ne pas distinguer actif/passé.  
 *En moyenne 1, max 2-3, très souvent 0*
 - **Actualités -> Publications** : publications en lien   
 *En moyenne 1, max 2-3, très souvent 0*
-- **Actualités -> People** : actualités à propos de cette personne.  
+- **Actualités -> People** : actualités à propos de cette personne. Ne pas distinguer actif/passé. 
 *en moyenne 2-3, max 5, régulièrement 0*
 
 
@@ -121,15 +126,18 @@ Champs :
 - **description** *fr/en* : présentation courte en une phrase ou deux rédigée par l'équipe éditoriale
 - **content** *fr/en* : contenu en markdown qui ne contient en général pas le contenu de la publication en entier mais son abstract
 - **date** : date de publication
-- **bibtex** : métadonnées complètes de la publication
+- **spireJson** : métadonnées complètes de la publication provenant de la plateforme biblio de Science Po
+- **authors** : liste des auteurs (rempli automatiquement si publi récupérée dans Spire)
+- **biblioRef** : référence biblio pour citer cette publication (rempli automatiquement si publi récupérée dans Spire)
+- **fullTextURL** : URL vers le plein texte, site de l'éditeur ou SPIRE... (rempli automatiquement si publi récupérée dans Spire)
 
 Liens : 
 
-- **Publications -> people** : les membres du médialab auteurs de la publi  
+- **Publications -> people** : les membres du médialab auteurs de la publi. ne pas distinguer actif/passé.  
 *minimum 1, max 6, moyenne 1.5*
-- **Publications -> activities** : les activités du médialab qui sont liées à cette publi
+- **Publications -> activities** : les activités du médialab qui sont liées à cette publi. Ne pas distinguer actif/passé.
 *en moyenne 1.5, max 4,  peut être 0 mais très rare*
-- **Publications -> publications** : liens vers d'autres publications liées
+- **Publications -> publications** : liens vers d'autres publications liées. 
 *en général 0, max 5*
 - **News -> publication** : les actualités qui ont mentionnées cette publi
 *en général 0, max 2* 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,45 @@
+# modèle de données
+
+## Activities
+
+label :
+- fr: Activités
+- en: Activities 
+
+Les activités décrivent les projets menés au médialab qui implémentent notre politique scientifique.
+Ces activités sont structurantes, collectives et durent un minimum dans le temps.
+Il y a trois types d'activités : recherche, méthode et pédagogique.
+
+Champs : 
+
+- **type** *mandatory* : trois valeurs possibles : recherche, méthode, pédagogie
+- **name** *fr/en*, *mandatory* : nom au sens de acronyme, nom officiel...
+- **baseline** *fr/en*, *mandatory* : phrase courte ou question posant le but de l'activité
+- **description** *fr/en*, *mandatory*: court paragraphe présentant l'activité 
+- **content** *fr/en*: le contenu riche (markdown) décrivant l'activité
+- **important** : boolean qui indique si l'activité est structurante. Ces activités sont par défaut mises en haut de liste. 
+- **active** : boolean qui indique si l'activité est active ou passée
+
+Liens :
+
+- **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. on ne liste pas toutes les personnes participants ponctuellement.  
+*En moyenne 2-3, minimum 1, max 10 personnes*
+- **Publication -> Activités** : activités qui ont suscité cette publication.  
+*En moyenne 1 ou 2, max 10, régulièrement 0*
+- **Actualités -> Activités** : actualités à propos de cette activité.  
+*en moyenne 3, max 10, régulièrement 0*
+
+
+## People
+
+label :
+
+- fr: Équipe
+- en: Team
+
+
+## Actualité
+## Publication
+
+papers and tools 
+publis et outils

--- a/specs/README.md
+++ b/specs/README.md
@@ -67,6 +67,7 @@ Distinction entre membre et associé.
 ## /!\ A discuter
 
 - **documentation** : documents associés genre pour un CV perso, site perso... ?
+- **picture** : pourquoi ne pas utiliser **illustration** ?
 ---
 
 Liens :

--- a/specs/README.md
+++ b/specs/README.md
@@ -118,5 +118,27 @@ Liens :
 
 ## Publication
 
-papers and tools 
-publis et outils
+Label :
+
+- en : papers and tools 
+- fr : publis et outils
+
+Champs : 
+
+- **type** *enum* : article/article, conférence/conference, livre/book, application web/web application, logiciel/software, exposition/exhibition, manuscript/working paper, corpus/dataset
+- **title** *fr/en*, *mandatory* : titre de la publication
+- **description** *fr/en* : présentation courte en une phrase ou deux rédigée par l'équipe éditoriale
+- **content** *fr/en* : contenu en markdown qui ne contient en général pas le contenu de la plublication en entier
+- **date** : date de publication
+- **bibtex** : métadonnées complètes de la publication
+
+Liens : 
+
+- **Publications -> people** : les membres du médialab auteurs de la publi  
+*minimum 1, max 6, moyenne 1.5*
+- **Publications -> activities** : les activités du médialab qui sont liées à cette publi
+*en moyenne 1.5, max 4,  peut être 0 mais très rare*
+- **Publications -> publications** : liens vers d'autres publications liées
+*en général 0, max 5*
+- **News -> publication** : les actualités qui ont mentionnées cette publi
+*en général 0, max 2* 

--- a/specs/README.md
+++ b/specs/README.md
@@ -21,15 +21,12 @@ Champs :
 - **documentation** : annexes, liste de média associés (document PDF, site web annexe, )
 - **important** : boolean qui indique si l'activité est structurante. Ces activités sont par défaut mises en haut de liste. 
 - **active** : boolean qui indique si l'activité est active ou passée
----
-## /!\ A discuter
+- **startDate** : date indiquée dans la page activité
+- **endDate** : date indiquée dans la page activité 
 
-- **documents** : documents associés ?
-- dates ?
----
 Liens :
 
-- **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. on ne liste pas toutes les personnes participants ponctuellement.  
+- **Activités -> People** : membres de l'équipe fortement impliquée dans l'activité. On ne liste pas toutes les personnes participants ponctuellement.  
 *En moyenne 2-3, minimum 1, max 10 personnes*
 - **Activités -> Activités** : activités qui sont proches, prolongation d'un projet par un autre, proximité thématique ou méthodo forte...  
 *En moyenne 2, max 4, souvent 0*
@@ -53,22 +50,16 @@ Les membres du médialab présents et passés. Toutes les personnes travaillant 
 Champs :
 - **FirstName** *mandatory*
 - **LastName** *mandatory*
-- **gender** : male, female.  
-Pour faire des générations de nom prenant en compte l'info notamment pour associé.e
 - **membership** : associate, member
 Distinction entre membre et associé.
 - **title** *fr/en*: titre académique/poste occupé
+- **description** : champs ouvert paragraphe
+- **domaine** : champs fermé
 - **contact** : information de contact, site perso, email... (on détecte les liens dans le template ?)
 - **bio** *fr/en*: contenu markdown
 - **active** : boolean indiquant si la personne est présentemment dans l'équipe
 - **picture** : photo (non traitée graphiquement ? en N&B)
 
----
-## /!\ A discuter
-
-- **documentation** : documents associés genre pour un CV perso, site perso... ?
-- **picture** : pourquoi ne pas utiliser **illustration** ?
----
 
 Liens :
 
@@ -77,7 +68,7 @@ Liens :
 - **Publications -> People** : publications de la personne.  
 *En moyenne 8, max 30, minimum 0 possible*
 - **Actualités -> People** : actualités à propos de cette personne.  
-*en moyenne 3-4, max 20, régulièrement 0*
+*en moyenne 3-4, max 12, régulièrement 0*
 
 Liens sélectionnés :
 
@@ -125,10 +116,10 @@ Label :
 
 Champs : 
 
-- **type** *enum* : article/article, conférence/conference, livre/book, application web/web application, logiciel/software, exposition/exhibition, manuscript/working paper, corpus/dataset
+- **type** *enum* : article/article, conférence/conference, livre/book, web/web, logiciel/software, exposition/exhibition, manuscript/working paper, corpus/dataset
 - **title** *fr/en*, *mandatory* : titre de la publication
 - **description** *fr/en* : présentation courte en une phrase ou deux rédigée par l'équipe éditoriale
-- **content** *fr/en* : contenu en markdown qui ne contient en général pas le contenu de la plublication en entier
+- **content** *fr/en* : contenu en markdown qui ne contient en général pas le contenu de la publication en entier mais son abstract
 - **date** : date de publication
 - **bibtex** : métadonnées complètes de la publication
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -82,7 +82,38 @@ Liens sélectionnés :
 
 On aimerait pouvoir mette en avant certains objets liés dans les activités et les publications. Sélectionner des 5 (?) plus importants par l'utilisateur pour les cas où il y a une longue liste.
 
-## Actualité
+## News
+
+Label : 
+- fr : Actualités
+- en : News
+
+Les actualités sont des contenus relatant la vie du labo. Ils indiquent les événements publics organisés par le labo ou où auxquels participent des membres du labo (rendez-vous); des recrutements, prix, nouveaux projets (annonces); des textes plus longs qui relatent un événement, une éxpérimentation menées au labo (chronique-billet-article).
+
+champs :
+
+- **type** : rendez-vous (event), chronique (post), annonce (notice)
+- **title** *fr/en* : titre en une courte phrase
+- **label** *fr/en* : qqs mots pour qualifier l'actualité, vocabulaire non contrôlé mais réutilisation fréquente des mêmes labels (auto-complétion dans le CMS).
+- **place** : lieux en qqs mots
+- **startDate** : date de début
+- **endDate** : date de fin
+- **description** *fr:en* : court paragraphe présentant l'actualité
+- **content** *fr/en*: contenu markdown
+- **internal** : boolean qui définit si le rendez-vous est organisé par nous ou pas
+- **illustration** : image d'illustration + sa version traité par le filtre graphique
+- **documentation** : annexes, liste de média associés (document PDF, site web annexe, )
+
+
+Liens :
+
+- **Actualités -> Activités** : Activités en lien avec l'actualité  
+*En moyenne 1, max 2-3, très souvent 0*
+- **Actualités -> Publications** : publications en lien   
+*En moyenne 1, max 2-3, très souvent 0*
+- **Actualités -> People** : actualités à propos de cette personne.  
+*en moyenne 2-3, max 5, régulièrement 0*
+
 
 ## Publication
 

--- a/specs/enums.json
+++ b/specs/enums.json
@@ -3,11 +3,29 @@
     "default": "research",
     "fr": {
       "research": "Recherche",
-      "teaching": "Enseignement"
+      "teaching": "Enseignement",
+      "method": "Méthode" 
     },
     "en": {
       "research": "Research",
-      "teaching": "Teaching"
+      "teaching": "Teaching",
+      "method": "Method"
+    }
+  },
+  "domains":{
+    "fr":{
+      "academic": "académique",
+      "technic": "technique",
+      "design": "design",
+      "pedagogic": "pédagogique",
+      "administrative": "vie du labo" 
+    },
+    "en":{
+      "academic": "academic",
+      "technic": "technic",
+      "design": "design",
+      "pedagogic": "pedagogy",
+      "administrative": "lab's life" 
     }
   },
   "membershipTypes": {
@@ -21,17 +39,38 @@
       "member": "Member"
     }
   },
+  "newsTypes": {
+    "default": "event",
+    "fr": {
+      "event": "Rendez-vous",
+      "post": "Chronique",
+      "notice": "Annonce"
+    },
+    "en": {
+      "event": "Event",
+      "post": "Post",
+      "notice": "Notice"
+    }
+  },
   "publicationTypes": {
     "default": "conference",
     "fr": {
+      "article": "Article",
       "conference": "Conférence",
-      "tool": "Outil",
-      "web": "Site web"
+      "book": "Livre",
+      "software": "Logiciel",
+      "web": "Site web",
+      "workingPaper": "Manuscrit",
+      "dataset": "Corpus"
     },
     "en": {
+      "article": "Article",
       "conference": "Conference",
-      "tool": "Tool",
-      "web": "Website"
+      "book": "Book",
+      "software": "Software",
+      "web": "Website",
+      "workingPaper": "Working paper",
+      "dataset": "Dataset"
     }
   }
 }

--- a/specs/enums.json
+++ b/specs/enums.json
@@ -56,21 +56,31 @@
     "default": "conference",
     "fr": {
       "article": "Article",
-      "conference": "Conférence",
+      "communication": "Communication",
       "book": "Livre",
+      "workingPaper": "Working paper",
+      "datascape": "Datascape",
+      "website": "Site web",
       "software": "Logiciel",
-      "web": "Site web",
-      "workingPaper": "Manuscrit",
-      "dataset": "Corpus"
+      "code": "Code",
+      "exhibition": "Exposition",
+      "workshop": "Atelier",
+      "simulation": "Simulation",
+      "conference": "Conférence"
     },
     "en": {
       "article": "Article",
-      "conference": "Conference",
+      "communication": "Communication",
       "book": "Book",
-      "software": "Software",
-      "web": "Website",
       "workingPaper": "Working paper",
-      "dataset": "Dataset"
+      "datascape": "Datascape",
+      "website": "Website",
+      "software": "Software",
+      "code": "Code",
+      "exhibition": "Exhibition",
+      "workshop": "Workshop",
+      "simulation": "Simulation",
+      "conference": "Conference"
     }
   }
 }

--- a/specs/enums.json
+++ b/specs/enums.json
@@ -4,7 +4,7 @@
     "fr": {
       "research": "Recherche",
       "teaching": "Enseignement",
-      "method": "Méthode" 
+      "method": "Méthode"
     },
     "en": {
       "research": "Research",
@@ -12,20 +12,20 @@
       "method": "Method"
     }
   },
-  "domains":{
-    "fr":{
+  "domains": {
+    "fr": {
       "academic": "académique",
-      "technic": "technique",
+      "tech": "technique",
       "design": "design",
-      "pedagogic": "pédagogique",
-      "administrative": "vie du labo" 
+      "pedagogy": "pédagogique",
+      "admin": "vie du labo"
     },
-    "en":{
+    "en": {
       "academic": "academic",
-      "technic": "technic",
+      "tech": "technic",
       "design": "design",
-      "pedagogic": "pedagogy",
-      "administrative": "lab's life" 
+      "pedagogy": "pedagogy",
+      "admin": "lab's life"
     }
   },
   "membershipTypes": {

--- a/specs/initializers.js
+++ b/specs/initializers.js
@@ -7,7 +7,8 @@ module.exports = {
       name: '',
       type: enums.activityTypes.default,
       draft: true,
-      active: true
+      active: true,
+      important: false
     };
   },
   people: function(uuid) {

--- a/specs/schemas/activities.json
+++ b/specs/schemas/activities.json
@@ -15,6 +15,10 @@
         "type": "string"
       }
     },
+    "oldSlug": {
+      "title": "Slug de l'ancien site",
+      "type": "string"
+    },
     "lastUpdated": {
       "title": "Timestamp of last update",
       "type": "number"
@@ -78,7 +82,7 @@
       }
     },
     "people": {
-      "title": "Gens impliqués",
+      "title": "Membres impliqués",
       "type": "array",
       "items": {
         "type": "string"

--- a/specs/schemas/activities.json
+++ b/specs/schemas/activities.json
@@ -85,6 +85,10 @@
       "formType": "ref",
       "model": "people"
     },
+    "important": {
+      "title": "Structurant?",
+      "type": "boolean"
+    },
     "active": {
       "title": "Actif?",
       "type": "boolean"

--- a/specs/schemas/activities.json
+++ b/specs/schemas/activities.json
@@ -85,6 +85,15 @@
       "formType": "ref",
       "model": "people"
     },
+    "activities": {
+      "title": "Activités liées",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "formType": "ref",
+      "model": "activities"
+    },
     "important": {
       "title": "Structurant?",
       "type": "boolean"

--- a/specs/schemas/activities.json
+++ b/specs/schemas/activities.json
@@ -56,9 +56,10 @@
       "type": "string",
       "enum": [
         "research",
-        "teaching"
+        "teaching",
+        "method"
       ],
-      "enumId": "activitiyTypes"
+      "enumId": "activityTypes"
     },
     "content": {
       "title": "Contenu",
@@ -101,6 +102,16 @@
     "active": {
       "title": "Actif?",
       "type": "boolean"
+    },
+    "startDate": {
+      "title": "Date de début",
+      "type": "string",
+      "formType": "vardate"
+    },
+    "endDate": {
+      "title": "Date de fin",
+      "type": "string",
+      "formType": "vardate"
     },
     "draft": {
       "title": "Draft?",

--- a/specs/schemas/news.json
+++ b/specs/schemas/news.json
@@ -19,6 +19,12 @@
       "title": "Timestamp of last update",
       "type": "number"
     },
+    "type":{
+      "title": "Type",
+      "type": "enum",
+      "enum": ["event","post","notice"],
+      "enumId": "newsTypes"
+    },
     "title": {
       "title": "Titre",
       "type": "object",
@@ -33,19 +39,23 @@
         }
       }
     },
-    "excerpt": {
-      "title": "Extrait",
+    "description": {
+      "title": "Description",
       "type": "object",
       "properties": {
         "en": {
-          "title": "English excerpt",
+          "title": "English description",
           "type": "string"
         },
         "fr": {
-          "title": "Extrait français",
+          "title": "Description en français",
           "type": "string"
         }
       }
+    },
+    "place": {
+      "title": "Lieux",
+      "type": "string"
     },
     "label": {
       "title": "Label",
@@ -116,6 +126,10 @@
       "type": "string",
       "formType": "vardate"
     },
+    "internal": {
+      "title": "Interne ?",
+      "type": "boolean"
+    }
     "draft": {
       "title": "Draft?",
       "type": "boolean"

--- a/specs/schemas/news.json
+++ b/specs/schemas/news.json
@@ -15,6 +15,10 @@
         "type": "string"
       }
     },
+    "oldSlug": {
+      "title": "Slug de l'ancien site",
+      "type": "string"
+    },
     "lastUpdated": {
       "title": "Timestamp of last update",
       "type": "number"

--- a/specs/schemas/news.json
+++ b/specs/schemas/news.json
@@ -129,7 +129,7 @@
     "internal": {
       "title": "Interne ?",
       "type": "boolean"
-    }
+    },
     "draft": {
       "title": "Draft?",
       "type": "boolean"

--- a/specs/schemas/news.json
+++ b/specs/schemas/news.json
@@ -23,10 +23,14 @@
       "title": "Timestamp of last update",
       "type": "number"
     },
-    "type":{
+    "type": {
       "title": "Type",
       "type": "string",
-      "enum": ["event","post","notice"],
+      "enum": [
+        "event",
+        "post",
+        "notice"
+      ],
       "enumId": "newsTypes"
     },
     "title": {

--- a/specs/schemas/news.json
+++ b/specs/schemas/news.json
@@ -21,7 +21,7 @@
     },
     "type":{
       "title": "Type",
-      "type": "enum",
+      "type": "string",
       "enum": ["event","post","notice"],
       "enumId": "newsTypes"
     },
@@ -55,7 +55,8 @@
     },
     "place": {
       "title": "Lieux",
-      "type": "string"
+      "type": "string",
+      "formType": "suggest"
     },
     "label": {
       "title": "Label",

--- a/specs/schemas/people.json
+++ b/specs/schemas/people.json
@@ -27,6 +27,12 @@
       "title": "Nom de famille",
       "type": "string"
     },
+    "gender":{
+      "title": "Genre",
+      "type": "enum",
+      "enum": ["male","female"],
+      "enumId": "genders"
+    },
     "title": {
       "title": "Titre",
       "type": "object",

--- a/specs/schemas/people.json
+++ b/specs/schemas/people.json
@@ -31,16 +31,16 @@
       "title": "Nom de famille",
       "type": "string"
     },
-    "function": {
+    "role": {
       "title": "Fonction",
       "type": "object",
       "properties": {
         "en": {
-          "title": "English title",
+          "title": "English function",
           "type": "string"
         },
         "fr": {
-          "title": "Titre français",
+          "title": "Fonction en français",
           "type": "string"
         }
       },
@@ -49,10 +49,16 @@
     "domain": {
       "title": "Domaine",
       "type": "string",
-      "enum": ["academic", "technic", "design", "pedagogic", "administrative"],
+      "enum": [
+        "academic",
+        "tech",
+        "design",
+        "pedagogy",
+        "admin"
+      ],
       "enumId" : "domains"
     },
-    "currentStatus": {
+    "status": {
       "title": "Occupation actuelle",
       "type": "object",
       "properties": {
@@ -124,12 +130,18 @@
       "title": "Draft?",
       "type": "boolean"
     },
-    "idSpire":{
-      "title": "id Spire",
-      "type": "string"
+    "spire": {
+      "title": "Informations SPIRE",
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Identifiant SPIRE",
+          "type": "string"
+        }
+      }
     },
-    "idLdap":{
-      "title": "Identifiant ldap",
+    "ldap":{
+      "title": "Identifiant LDAP",
       "type": "string"
     }
   },

--- a/specs/schemas/people.json
+++ b/specs/schemas/people.json
@@ -15,6 +15,10 @@
         "type": "string"
       }
     },
+    "oldSlug": {
+      "title": "Slug de l'ancien site",
+      "type": "string"
+    },
     "lastUpdated": {
       "title": "Timestamp of last update",
       "type": "number"
@@ -27,8 +31,8 @@
       "title": "Nom de famille",
       "type": "string"
     },
-    "title": {
-      "title": "Titre",
+    "function": {
+      "title": "Fonction",
       "type": "object",
       "properties": {
         "en": {
@@ -39,7 +43,8 @@
           "title": "Titre français",
           "type": "string"
         }
-      }
+      },
+      "formType": "suggest"
     },
     "domain": {
       "title": "Domaine",
@@ -93,7 +98,7 @@
       ],
       "enumId": "membershipTypes"
     },
-    "main_activities": {
+    "mainActivities": {
       "title": "Activités principales",
       "type": "array",
       "items": {
@@ -102,7 +107,7 @@
       "formType": "ref",
       "model": "activities"
     },
-    "main_publications": {
+    "mainPublications": {
       "title": "Publications principales",
       "type": "array",
       "items": {
@@ -121,6 +126,10 @@
     },
     "idSpire":{
       "title": "id Spire",
+      "type": "string"
+    },
+    "idLdap":{
+      "title": "Identifiant ldap",
       "type": "string"
     }
   },

--- a/specs/schemas/people.json
+++ b/specs/schemas/people.json
@@ -27,12 +27,6 @@
       "title": "Nom de famille",
       "type": "string"
     },
-    "gender":{
-      "title": "Genre",
-      "type": "enum",
-      "enum": ["male","female"],
-      "enumId": "genders"
-    },
     "title": {
       "title": "Titre",
       "type": "object",
@@ -43,6 +37,26 @@
         },
         "fr": {
           "title": "Titre français",
+          "type": "string"
+        }
+      }
+    },
+    "domain": {
+      "title": "Domaine",
+      "type": "string",
+      "enum": ["academic", "technic", "design", "pedagogic", "administrative"],
+      "enumId" : "domains"
+    },
+    "currentStatus": {
+      "title": "Occupation actuelle",
+      "type": "object",
+      "properties": {
+        "en": {
+          "title": "Current status",
+          "type": "string"
+        },
+        "fr": {
+          "title": "Occupation actuelle",
           "type": "string"
         }
       }
@@ -63,6 +77,13 @@
         }
       }
     },
+    "contact": {
+      "title": "Contact",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "membership": {
       "title": "Type de membre",
       "type": "string",
@@ -72,6 +93,24 @@
       ],
       "enumId": "membershipTypes"
     },
+    "main_activities": {
+      "title": "Activités principales",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "formType": "ref",
+      "model": "activities"
+    },
+    "main_publications": {
+      "title": "Publications principales",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "formType": "ref",
+      "model": "publications"
+    },
     "active": {
       "title": "Actif?",
       "type": "boolean"
@@ -79,6 +118,10 @@
     "draft": {
       "title": "Draft?",
       "type": "boolean"
+    },
+    "idSpire":{
+      "title": "id Spire",
+      "type": "string"
     }
   },
   "required": [

--- a/specs/schemas/publications.json
+++ b/specs/schemas/publications.json
@@ -33,16 +33,16 @@
         }
       }
     },
-    "abstract": {
-      "title": "Résumé",
+    "description": {
+      "title": "Description",
       "type": "object",
       "properties": {
         "en": {
-          "title": "English abstract",
+          "title": "Description in english",
           "type": "string"
         },
         "fr": {
-          "title": "Résumé français",
+          "title": "Description en français",
           "type": "string"
         }
       }
@@ -51,9 +51,13 @@
       "title": "Type de la publication",
       "type": "string",
       "enum": [
+        "article",
+        "livre",
         "conference",
-        "tool",
-        "web"
+        "logiciel",
+        "web",
+        "manuscript",
+        "corpus"
       ],
       "enumId": "publicationTypes"
     },

--- a/specs/schemas/publications.json
+++ b/specs/schemas/publications.json
@@ -113,11 +113,6 @@
       "type": "string",
       "formType": "vardate"
     },
-    "spireJson": {
-      "title": "Bibtex",
-      "type": "string",
-      "formType": "vardate"
-    },
     "people": {
       "title": "Membres du labo",
       "type": "array",
@@ -127,12 +122,11 @@
       "formType": "ref",
       "model": "people"
     },
-    "biblioRef": {
+    "ref": {
       "title": "Référence biblio",
-      "type": "string",
-      "formType": "content"
+      "type": "string"
     },
-    "URL": {
+    "url": {
       "title": "Lien externe",
       "type": "string"
     },
@@ -144,9 +138,19 @@
       "title": "Actif?",
       "type": "boolean"
     },
-    "idSpire": {
-      "title": "id Spire",
-      "type" : "string"
+    "spire": {
+      "title": "Information SPIRE",
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Identifiant SPIRE",
+          "type": "string"
+        },
+        "meta": {
+          "title": "Metadonnées SPIRE",
+          "type": "object"
+        }
+      }
     }
   }
 }

--- a/specs/schemas/publications.json
+++ b/specs/schemas/publications.json
@@ -109,6 +109,11 @@
       "type": "string",
       "formType": "vardate"
     },
+    "bibtex": {
+      "title": "Bibtex",
+      "type": "string",
+      "formType": "vardate"
+    },
     "draft": {
       "title": "Draft?",
       "type": "boolean"

--- a/specs/schemas/publications.json
+++ b/specs/schemas/publications.json
@@ -15,6 +15,10 @@
         "type": "string"
       }
     },
+    "oldSlug": {
+      "title": "Slug de l'ancien site",
+      "type": "string"
+    },
     "lastUpdated": {
       "title": "Timestamp of last update",
       "type": "number"
@@ -53,11 +57,16 @@
       "enum": [
         "article",
         "book",
-        "conference",
-        "software",
-        "web",
+        "communication",
         "workingPaper",
-        "dataset"
+        "datascape",
+        "website",
+        "software",
+        "code",
+        "exhibition",
+        "simulation",
+        "workshop",
+        "conference"
       ],
       "enumId": "publicationTypes"
     },
@@ -86,14 +95,9 @@
       "formType": "ref",
       "model": "activities"
     },
-    "people": {
-      "title": "Gens impliqués",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "formType": "ref",
-      "model": "people"
+    "authors": {
+      "title": "Auteurs",
+      "type": "string"
     },
     "publications": {
       "title": "Publications liées",
@@ -114,24 +118,30 @@
       "type": "string",
       "formType": "vardate"
     },
-    "authors": {
-      "title": "Auteurs",
+    "people": {
+      "title": "Membres du labo",
       "type": "array",
       "items": {
-        "type": "object"
-      }
+        "type": "string"
+      },
+      "formType": "ref",
+      "model": "people"
     },
     "biblioRef": {
       "title": "Référence biblio",
       "type": "string",
       "formType": "content"
     },
-    "fullTextURL": {
-      "title": "Lien vers le texte plein",
+    "URL": {
+      "title": "Lien externe",
       "type": "string"
     },
     "draft": {
       "title": "Draft?",
+      "type": "boolean"
+    },
+    "active": {
+      "title": "Actif?",
       "type": "boolean"
     },
     "idSpire": {

--- a/specs/schemas/publications.json
+++ b/specs/schemas/publications.json
@@ -52,12 +52,12 @@
       "type": "string",
       "enum": [
         "article",
-        "livre",
+        "book",
         "conference",
-        "logiciel",
+        "software",
         "web",
-        "manuscript",
-        "corpus"
+        "workingPaper",
+        "dataset"
       ],
       "enumId": "publicationTypes"
     },
@@ -109,14 +109,34 @@
       "type": "string",
       "formType": "vardate"
     },
-    "bibtex": {
+    "spireJson": {
       "title": "Bibtex",
       "type": "string",
       "formType": "vardate"
     },
+    "authors": {
+      "title": "Auteurs",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "biblioRef": {
+      "title": "Référence biblio",
+      "type": "string",
+      "formType": "content"
+    },
+    "fullTextURL": {
+      "title": "Lien vers le texte plein",
+      "type": "string"
+    },
     "draft": {
       "title": "Draft?",
       "type": "boolean"
+    },
+    "idSpire": {
+      "title": "id Spire",
+      "type" : "string"
     }
   }
 }


### PR DESCRIPTION
Nouveau modèle de données et documentation associée.
Ce modèle n'est pas encore intégré au CMS et donc non fonctionnel.
De nombreux changements mais un impact majeur est le changement de nom du modèle publications qui devient productions.


ps: La branche new_mode_cherry-picked a été comme son nom l'indique recréée par cherry-pick pour l'isoler de interface_00.