### PR TITLE
Move preview

### DIFF
--- a/admin/src/components/Preview.js
+++ b/admin/src/components/Preview.js
@@ -1,7 +1,7 @@
 /* global STATIC_URL */
 import React from 'react';
 
-export default function Preview({url}) {
+export default function Preview({url, onClose}) {
   const absoluteUrl = `${STATIC_URL}/${url}`;
 
   return (
@@ -9,6 +9,7 @@ export default function Preview({url}) {
       <p style={{marginBottom: '10px'}}>
         <strong>Preview link</strong>: <a href={absoluteUrl} target="_blank" rel="noopener noreferrer">{absoluteUrl}</a>
       </p>
+      <button onClick={onClose}>Close</button>
       <iframe
         style={{border: '1px solid #dbdbdb', width: '100%', height: 'calc(100vh - 200px)'}}
         src={absoluteUrl} />

--- a/admin/src/components/Preview.js
+++ b/admin/src/components/Preview.js
@@ -1,7 +1,7 @@
 /* global STATIC_URL */
 import React from 'react';
 
-export default function Preview({url, onClose}) {
+export default function Preview({url}) {
   const absoluteUrl = `${STATIC_URL}/${url}`;
 
   return (
@@ -9,7 +9,6 @@ export default function Preview({url, onClose}) {
       <p style={{marginBottom: '10px'}}>
         <strong>Preview link</strong>: <a href={absoluteUrl} target="_blank" rel="noopener noreferrer">{absoluteUrl}</a>
       </p>
-      <button onClick={onClose}>Close</button>
       <iframe
         style={{border: '1px solid #dbdbdb', width: '100%', height: 'calc(100vh - 200px)'}}
         src={absoluteUrl} />

--- a/admin/src/components/forms/ActivityForm.js
+++ b/admin/src/components/forms/ActivityForm.js
@@ -78,7 +78,8 @@ function renderActivityForm(props) {
     handlers,
     slug,
     englishEditorContent,
-    frenchEditorContent
+    frenchEditorContent,
+    children
   } = props;
 
   return (
@@ -106,6 +107,7 @@ function renderActivityForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
+              {children}
             </div>
           </div>
         </div>

--- a/admin/src/components/forms/ActivityForm.js
+++ b/admin/src/components/forms/ActivityForm.js
@@ -82,7 +82,7 @@ function renderActivityForm(props) {
     slug,
     englishEditorContent,
     frenchEditorContent,
-    children
+    slugRenderer
   } = props;
 
   return (
@@ -109,7 +109,7 @@ function renderActivityForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
-              {children}
+              {slugRenderer(props)}
             </div>
           </div>
         </div>

--- a/admin/src/components/forms/ActivityForm.js
+++ b/admin/src/components/forms/ActivityForm.js
@@ -12,8 +12,11 @@ import RelationSelector from '../selectors/RelationSelector';
 import SortableKeyValueList from '../selectors/SortableKeyValueList';
 
 function validate(data) {
-  if (!data.name)
-    return 'Need at least a name';
+  if (!data.name) {
+    return 'A name is required';
+  }
+  if (!slugifyActivity(data).length)
+    return 'A name with at least one valid characters is required';
 }
 
 const HANDLERS = {
@@ -84,7 +87,6 @@ function renderActivityForm(props) {
 
   return (
     <div className="container">
-
       <div className="form-group">
         <div className="columns">
           <div className="column is-6">

--- a/admin/src/components/forms/ActivityForm.js
+++ b/admin/src/components/forms/ActivityForm.js
@@ -1,3 +1,4 @@
+/* global STATIC_URL */
 import React from 'react';
 
 import initializers from '../../../../specs/initializers';
@@ -10,6 +11,7 @@ import DateSelector from '../selectors/DateSelector';
 import BooleanSelector from '../selectors/BooleanSelector';
 import RelationSelector from '../selectors/RelationSelector';
 import SortableKeyValueList from '../selectors/SortableKeyValueList';
+import PreviewLink from '../misc/PreviewLink';
 
 function validate(data) {
   if (!data.name) {
@@ -82,7 +84,8 @@ function renderActivityForm(props) {
     slug,
     englishEditorContent,
     frenchEditorContent,
-    slugRenderer
+    url,
+    dirty
   } = props;
 
   return (
@@ -109,7 +112,7 @@ function renderActivityForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
-              {slugRenderer(props)}
+              {url && <PreviewLink url={url} disabled={dirty} />}
             </div>
           </div>
         </div>

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -395,8 +395,8 @@ class Form extends Component {
           message={navigationPromptMessage} />
         <div>
           {
-            cond([
-              [isEditPage, constant(children({
+            condWithConstants([
+              [isEditPage, children({
                   handlers: this.handlers,
                   englishEditorContent: this.englishEditorContent,
                   frenchEditorContent: this.frenchEditorContent,
@@ -413,9 +413,9 @@ class Form extends Component {
                         rel="noopener noreferrer">{`${STATIC_URL}/${URL}`}</a>}
                     </div>
                   )
-                }))],
-              [isFrenchPage, constant(<Preview url={URL} />)],
-              [stubTrue, constant(<Preview url={`en/${URL}`} />)]
+                })],
+              [isFrenchPage, <Preview key="preview" url={URL} />],
+              [stubTrue, <Preview key="preview" url={`en/${URL}`} />]
             ])(state)
           }
           <p style={{height: '70px'}} />

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -1,3 +1,4 @@
+/* global STATIC_URL */
 /* eslint no-nested-ternary: 0 */
 /* eslint no-alert: 0 */
 /* eslint react/forbid-prop-types: 0 */
@@ -10,6 +11,7 @@ import {Link, Prompt} from 'react-router-dom';
 import uuid from 'uuid/v4';
 import get from 'lodash/fp/get';
 import set from 'lodash/fp/set';
+import last from 'lodash/fp/last';
 import cls from 'classnames';
 
 import client from '../../client';
@@ -358,14 +360,24 @@ class Form extends Component {
     }
 
     let body = null;
-
     if (view === 'edit') {
       const renderedForm = children({
         handlers: this.handlers,
         englishEditorContent: this.englishEditorContent,
         frenchEditorContent: this.frenchEditorContent,
         slug,
-        data
+        data,
+        children: (
+          !isNew && <div style={{marginBottom: '10px'}}>
+            <label className="label is-inline">
+              Preview link:{' '}
+            </label>
+            {slug && <a
+              href={`${STATIC_URL}/${model}/${slug}`}
+              target="_blank"
+              rel="noopener noreferrer">{`${STATIC_URL}/${model}/${slug}`}</a>}
+          </div>
+        )
       });
 
       body = (
@@ -396,6 +408,31 @@ class Form extends Component {
                   )}
                 </div>
               </div>
+              <div className="level-right">
+                <div className="field is-grouped">
+                  {!isNew && (
+                    <React.Fragment>
+                      <div className="field-label is-normal">
+                        <p className={cls(dirty && !validationError ? '' : 'has-text-grey')}>Preview {pageLabel} page:</p>
+                      </div>
+                      <div className="control">
+                        <Button
+                          kind={dirty && !validationError ? 'success' : 'white'}
+                          disabled={!dirty || validationError}
+                          loading={saving}
+                          onClick={this.toggleFrenchPreview}>French</Button>
+                      </div>
+                      <div className="control">
+                        <Button
+                          kind={dirty && !validationError ? 'success' : 'white'}
+                          disabled={!dirty || validationError}
+                          loading={saving}
+                          onClick={this.toggleEnglishPreview}>English</Button>
+                      </div>
+                    </React.Fragment>
+                    )}
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -403,11 +440,11 @@ class Form extends Component {
     }
 
     else if (view === 'preview-fr') {
-      body = <Preview url={`${model}/${data.slugs[data.slugs.length - 1]}`} />;
+      body = <Preview onClose={this.toggleEdit} url={`${model}/${data.slugs[data.slugs.length - 1]}`} />;
     }
 
     else {
-      body = <Preview url={`en/${model}/${data.slugs[data.slugs.length - 1]}`} />;
+      body = <Preview onClose={this.toggleEdit} url={`en/${model}/${data.slugs[data.slugs.length - 1]}`} />;
     }
 
     return (
@@ -422,29 +459,6 @@ class Form extends Component {
         <Prompt
           when={!saving && dirty}
           message={navigationPromptMessage} />
-        <div className="tabs is-boxed">
-          <ul>
-            <li
-              className={cls(view === 'edit' && 'is-active')}
-              onClick={this.toggleEdit}>
-              <a>Edit {pageLabel}</a>
-            </li>
-            {!isNew && (
-              <li
-                className={cls(view === 'preview-fr' && 'is-active')}
-                onClick={this.toggleFrenchPreview}>
-                <a>Preview French {pageLabel} page</a>
-              </li>
-            )}
-            {!isNew && (
-              <li
-                className={cls(view === 'preview-en' && 'is-active')}
-                onClick={this.toggleEnglishPreview}>
-                <a>Preview English {pageLabel} page</a>
-              </li>
-            )}
-          </ul>
-        </div>
         {body}
       </div>
     );

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -406,17 +406,8 @@ class Form extends Component {
                   frenchEditorContent: this.frenchEditorContent,
                   slug,
                   data,
-                  slugRenderer: () => (
-                    !isNew && <div style={{marginBottom: '10px'}}>
-                      <label className="label is-inline">
-                        Preview link:{' '}
-                      </label>
-                      {slug && <a
-                        href={`${STATIC_URL}/${URL}`}
-                        target="_blank"
-                        rel="noopener noreferrer">{`${STATIC_URL}/${URL}`}</a>}
-                    </div>
-                  )
+                  url: !isNew && `${STATIC_URL}/${URL}`,
+                  dirty
                 })],
               [isFrenchPage, <Preview key="preview" url={URL} />],
               [stubTrue, <Preview key="preview" url={`en/${URL}`} />]

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -402,7 +402,7 @@ class Form extends Component {
                   frenchEditorContent: this.frenchEditorContent,
                   slug,
                   data,
-                  children: (
+                  slugRenderer: () => (
                     !isNew && <div style={{marginBottom: '10px'}}>
                       <label className="label is-inline">
                         Preview link:{' '}

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -21,6 +21,7 @@ import map from 'lodash/fp/map';
 import constant from 'lodash/fp/constant';
 import overEvery from 'lodash/fp/overEvery';
 import isFunction from 'lodash/fp/isFunction';
+import overSome from 'lodash/fp/overSome';
 import cls from 'classnames';
 
 import client from '../../client';
@@ -49,9 +50,12 @@ const fnButtonKind = condWithConstants([
   [isItSignaling, 'success'],
   [isNotEditPage, 'danger'],
   [
-    overEvery([
-      isDirty,
-      negate(isThereErrors)
+    overSome([
+      overEvery([
+        isDirty,
+        negate(isThereErrors)
+      ]),
+      ({saving}) => saving
     ]),
     'info'
   ],
@@ -425,6 +429,7 @@ class Form extends Component {
                 <div className="field is-grouped">
                   <div className="control">
                     <Button
+                      className="button__animated-color"
                       kind={fnButtonKind(state)}
                       disabled={fnDisabled(state)}
                       loading={saving}
@@ -455,11 +460,13 @@ class Form extends Component {
                       </div>
                       <div className="control">
                         <Button
+                          className="button__animated-color"
                           {...previewPropsFilter('preview-fr')}
                           onClick={this.toggleFrenchPreview}>French</Button>
                       </div>
                       <div className="control">
                         <Button
+                          className="button__animated-color"
                           {...previewPropsFilter('preview-en')}
                           onClick={this.toggleEnglishPreview}>English</Button>
                       </div>

--- a/admin/src/components/forms/Form.js
+++ b/admin/src/components/forms/Form.js
@@ -413,19 +413,19 @@ class Form extends Component {
                   {!isNew && (
                     <React.Fragment>
                       <div className="field-label is-normal">
-                        <p className={cls(dirty && !validationError ? '' : 'has-text-grey')}>Preview {pageLabel} page:</p>
+                        <p className={cls(validationError && 'has-text-grey')}>Preview {pageLabel} page:</p>
                       </div>
                       <div className="control">
                         <Button
-                          kind={dirty && !validationError ? 'success' : 'white'}
-                          disabled={!dirty || validationError}
+                          kind={!validationError ? 'success' : 'white'}
+                          disabled={validationError}
                           loading={saving}
                           onClick={this.toggleFrenchPreview}>French</Button>
                       </div>
                       <div className="control">
                         <Button
-                          kind={dirty && !validationError ? 'success' : 'white'}
-                          disabled={!dirty || validationError}
+                          kind={!validationError ? 'success' : 'white'}
+                          disabled={validationError}
                           loading={saving}
                           onClick={this.toggleEnglishPreview}>English</Button>
                       </div>

--- a/admin/src/components/forms/NewsForm.js
+++ b/admin/src/components/forms/NewsForm.js
@@ -10,6 +10,7 @@ import DateSelector from '../selectors/DateSelector';
 import EnumSelector from '../selectors/EnumSelector';
 import RelationSelector from '../selectors/RelationSelector';
 import SuggestionSelector from '../selectors/SuggestionSelector';
+import PreviewLink from '../misc/PreviewLink';
 
 function validate(data) {
   if (!data.title || !data.title.fr)
@@ -93,6 +94,8 @@ function renderNewsForm(props) {
     data,
     handlers,
     slug,
+    url,
+    dirty,
     englishEditorContent,
     frenchEditorContent
   } = props;
@@ -138,6 +141,7 @@ function renderNewsForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
+              {url && <PreviewLink url={url} disabled={dirty} />}
             </div>
           </div>
         </div>

--- a/admin/src/components/forms/PeopleForm.js
+++ b/admin/src/components/forms/PeopleForm.js
@@ -11,6 +11,7 @@ import BooleanSelector from '../selectors/BooleanSelector';
 import RelationSelector from '../selectors/RelationSelector';
 import SortableKeyValueList from '../selectors/SortableKeyValueList';
 import SuggestionSelector from '../selectors/SuggestionSelector';
+import PreviewLink from '../misc/PreviewLink';
 
 function validate(data) {
   if (!data.firstName || !data.lastName)
@@ -86,7 +87,8 @@ function renderPeopleForm(props) {
     handlers,
     slug,
     englishEditorContent,
-    frenchEditorContent
+    frenchEditorContent,
+    dirty, url
   } = props;
 
   return (
@@ -127,6 +129,7 @@ function renderPeopleForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
+              {url && <PreviewLink url={url} disabled={dirty} />}
             </div>
           </div>
         </div>

--- a/admin/src/components/forms/ProductionForm.js
+++ b/admin/src/components/forms/ProductionForm.js
@@ -10,6 +10,7 @@ import DateSelector from '../selectors/DateSelector';
 import EnumSelector from '../selectors/EnumSelector';
 import RelationSelector from '../selectors/RelationSelector';
 import UrlInput from '../selectors/UrlInput';
+import PreviewLink from '../misc/PreviewLink';
 
 function validate(data) {
   if (!data.title || !data.title.fr)
@@ -75,7 +76,9 @@ function renderProductionForm(props) {
     handlers,
     slug,
     englishEditorContent,
-    frenchEditorContent
+    frenchEditorContent,
+    url,
+    dirty
   } = props;
 
   return (
@@ -119,6 +122,7 @@ function renderProductionForm(props) {
           <div className="column is-12">
             <div className="field">
               <label className="label" style={{display: 'inline'}}>Slug:</label> {slug && <code>{slug}</code>}
+              {url && <PreviewLink url={url} disabled={dirty} />}
             </div>
           </div>
         </div>

--- a/admin/src/components/misc/Button.js
+++ b/admin/src/components/misc/Button.js
@@ -13,6 +13,7 @@ export default function Button(props) {
   } = props;
 
   const className = cls(
+    props.className,
     'button',
     loading && 'is-loading',
     rounded && 'is-rounded',

--- a/admin/src/components/misc/PreviewLink.js
+++ b/admin/src/components/misc/PreviewLink.js
@@ -1,0 +1,13 @@
+import React, {memo} from 'react';
+
+export default memo(props => (
+  <div style={{marginBottom: '10px'}}>
+    <label className="label is-inline">
+      Preview link:{' '}
+    </label>
+    {props.disabled ? <span>{props.url}</span> : <a
+      href={props.url}
+      target="_blank"
+      rel="noopener noreferrer">{props.url}</a>}
+  </div>
+));

--- a/admin/style/main.scss
+++ b/admin/style/main.scss
@@ -150,3 +150,7 @@ $table-header-color: #dbdbdb;
   background-color: white;
   z-index: 500
 }
+
+.button__animated-color {
+  transition: background-color 0.3s ease;
+}

--- a/admin/style/main.scss
+++ b/admin/style/main.scss
@@ -144,7 +144,7 @@ $table-header-color: #dbdbdb;
 .footer-container {
   border-top: 1px solid #dbdbdb;
   box-shadow: 0px -5px 7px -5px #ddd;
-  padding: 10px;
+  padding: 10px 0;
   position: fixed;
   bottom: 0px;
   background-color: white;

--- a/admin/style/main.scss
+++ b/admin/style/main.scss
@@ -116,3 +116,12 @@ li {
   }
 }
 
+.footer-container {
+  border-top: 1px solid #dbdbdb;
+  box-shadow: 0px -5px 7px -5px #ddd;
+  padding: 10px;
+  position: fixed;
+  bottom: 0px;
+  background-color: white;
+  z-index: 500
+}


### PR DESCRIPTION
Previews have been moved to the footer opposed to the ``save`` button.
When visualizing a preview, the ``save`` button transforms into a ``close preview`` button. With this solution we only use existing CTAs.

Small transitions as been added to thoses footer buttons.