### PR TITLE
Flux RSS

### DIFF
--- a/site/feeds.js
+++ b/site/feeds.js
@@ -11,6 +11,8 @@ const languageFallback = (obj, lang) => {
     }
 };
 
+const FEED_MAX_NUMBER_OF_ITEMS = 50;
+
 const feedsMakers = [
     /**
      * News feeds maker
@@ -19,6 +21,7 @@ const feedsMakers = [
         serialize: ({ query: { allNewsJson } }) => {
           return allNewsJson.edges
           .filter(edge => !edge.node.draft)
+          .filter((e, i) => i < FEED_MAX_NUMBER_OF_ITEMS)
           .sort((a, b) => {
             if (a.node.startDate > b.node.startDate) {
               return -1;
@@ -79,6 +82,7 @@ const feedsMakers = [
             } else return 1;
           })
           .filter(edge => !edge.node.draft && edge.node.label && edge.node.label.fr ===  'Séminaire de recherche')
+          .filter((e, i) => i < FEED_MAX_NUMBER_OF_ITEMS)
           .map(edge => {
             return Object.assign( {
               title: edge.node.title[lang],
@@ -133,6 +137,7 @@ const feedsMakers = [
         serialize: ({ query: { allProductionsJson } }) => {
           return allProductionsJson.edges
           .filter(edge => !edge.node.draft)
+          .filter((e, i) => i < FEED_MAX_NUMBER_OF_ITEMS)
           .sort((a, b) => {
             if (a.node.date > b.node.date) {
               return -1;

--- a/site/feeds.js
+++ b/site/feeds.js
@@ -1,0 +1,195 @@
+const languageFallback = (obj, lang) => {
+    if (obj) {
+        if (obj[lang]) {
+            return obj[lang];
+        } else {
+            const other = lang === 'fr' ? 'en' : 'fr';
+            if (obj[other]) {
+                return obj[other]
+            }
+        }
+    }
+};
+
+const feedsMakers = [
+    /**
+     * News feeds maker
+     */
+    lang => ({
+        serialize: ({ query: { allNewsJson } }) => {
+          return allNewsJson.edges
+          .filter(edge => !edge.node.draft)
+          .sort((a, b) => {
+            if (a.node.startDate > b.node.startDate) {
+              return -1;
+            } else return 1;
+          })
+          .map(edge => {
+            return Object.assign( {
+              title: languageFallback(edge.node.title, lang),
+              description: languageFallback(edge.node.description, lang),
+              date: edge.node.startDate,
+              url: edge.node.permalink[lang],
+              guid: edge.node.id,
+              custom_elements: [{ 'content:encoded': languageFallback(edge.node.content, lang) }],
+            })
+          })
+        },
+        query: `
+          {
+            allNewsJson {
+              edges {
+                node {
+                  id
+                  title {
+                    en
+                    fr
+                  }
+                  draft
+                  description {
+                    en
+                    fr
+                  }
+                  startDate
+                  permalink {
+                    en
+                    fr
+                  }
+                  content {
+                    en
+                    fr
+                  }
+                }
+              }
+            }
+          }
+        `,
+        output: lang === 'fr' ? '/actualites.feed.xml' : '/news.feed.xml',
+        title: lang === 'fr' ? 'Actualités du médialab Sciences Po' : 'News from médialab SciencesPo',
+    }),
+    /**
+     * Seminar sessions feeds maker
+     */
+    lang => ({
+        serialize: ({ query: { allNewsJson } }) => {
+          return allNewsJson.edges
+          .sort((a, b) => {
+            if (a.node.startDate > b.node.startDate) {
+              return -1;
+            } else return 1;
+          })
+          .filter(edge => !edge.node.draft && edge.node.label && edge.node.label.fr ===  'Séminaire de recherche')
+          .map(edge => {
+            return Object.assign( {
+              title: edge.node.title[lang],
+              description: languageFallback(edge.node.description, lang),
+              date: edge.node.startDate,
+              url: edge.node.permalink[lang],
+              guid: edge.node.id,
+              custom_elements: [{ 'content:encoded': languageFallback(edge.node.content, lang) }],
+            })
+          })
+        },
+        query: `
+          {
+            allNewsJson {
+              edges {
+                node {
+                  id
+                  title {
+                    en
+                    fr
+                  }
+                  draft
+                  description {
+                    en
+                    fr
+                  }
+                  label {
+                    en
+                    fr
+                  }
+                  startDate
+                  permalink {
+                    en
+                    fr
+                  }
+                  content {
+                    en
+                    fr
+                  }
+                }
+              }
+            }
+          }
+        `,
+        output: lang === 'fr' ? '/seminaire.feed.xml' : '/seminar.feed.xml',
+        title: lang === 'fr' ? 'Actualités du séminaire médialab Sciences Po' : 'News from médialab SciencesPo\s seminar',
+    }),
+    /**
+     * Productions feeds maker
+     */
+    lang => ({
+        serialize: ({ query: { allProductionsJson } }) => {
+          return allProductionsJson.edges
+          .filter(edge => !edge.node.draft)
+          .sort((a, b) => {
+            if (a.node.date > b.node.date) {
+              return -1;
+            } else return 1;
+          })
+          .map(edge => {
+            return Object.assign( {
+              title: `${languageFallback(edge.node.title, lang)} - ${edge.node.authors}`,
+              description: languageFallback(edge.node.description, lang),
+              date: edge.node.date,
+              url: edge.node.permalink[lang],
+              guid: edge.node.id,
+              custom_elements: [{ 'content:encoded': languageFallback(edge.node.content, lang) }],
+            })
+          })
+        },
+        query: `
+          {
+            allProductionsJson {
+              edges {
+                node {
+                  id
+                  title {
+                    en
+                    fr
+                  }
+                  description {
+                    en
+                    fr
+                  }
+                  authors
+                  date
+                  draft
+                  permalink {
+                    en
+                    fr
+                  }
+                  content {
+                    en
+                    fr
+                  }
+                }
+              }
+            }
+          }
+        `,
+        output: lang === 'fr' ? '/productions-fr.feed.xml' : '/productions-en.feed.xml',
+        title: lang === 'fr' ? 'Nouvelles productions du médialab Sciences Po' : 'New productions from médialab SciencesPo\s',
+    }),
+];
+
+const feeds = feedsMakers.reduce((result, feedMaker) => {
+    return [
+        ...result,
+        feedMaker('fr'),
+        feedMaker('en')
+    ];
+}, []);
+
+module.exports = feeds;

--- a/site/feeds.js
+++ b/site/feeds.js
@@ -85,7 +85,7 @@ const feedsMakers = [
           .filter((e, i) => i < FEED_MAX_NUMBER_OF_ITEMS)
           .map(edge => {
             return Object.assign( {
-              title: edge.node.title[lang],
+              title: languageFallback(edge.node.title, lang),
               description: languageFallback(edge.node.description, lang),
               date: edge.node.startDate,
               url: edge.node.permalink[lang],

--- a/site/feeds.js
+++ b/site/feeds.js
@@ -128,7 +128,7 @@ const feedsMakers = [
           }
         `,
         output: lang === 'fr' ? '/seminaire.feed.xml' : '/seminar.feed.xml',
-        title: lang === 'fr' ? 'Actualités du séminaire médialab Sciences Po' : 'News from médialab SciencesPo\s seminar',
+        title: lang === 'fr' ? 'Actualités du séminaire médialab Sciences Po' : 'News from médialab SciencesPo\'s seminar',
     }),
     /**
      * Productions feeds maker
@@ -185,7 +185,7 @@ const feedsMakers = [
           }
         `,
         output: lang === 'fr' ? '/productions-fr.feed.xml' : '/productions-en.feed.xml',
-        title: lang === 'fr' ? 'Nouvelles productions du médialab Sciences Po' : 'New productions from médialab SciencesPo\s',
+        title: lang === 'fr' ? 'Nouvelles productions du médialab Sciences Po' : 'New productions from médialab SciencesPo',
     }),
     /**
      * All objects feeds maker
@@ -356,7 +356,7 @@ const feedsMakers = [
         }
       `,
       output: lang === 'fr' ? '/all-updates-fr.feed.xml' : '/all-updates-en.feed.xml',
-      title: lang === 'fr' ? 'Toutes les mises à jour du médialab Sciences Po' : 'All updates from médialab SciencesPo\s',
+      title: lang === 'fr' ? 'Toutes les mises à jour du médialab Sciences Po' : 'All updates from médialab SciencesPo',
   }),
 ];
 

--- a/site/feeds.js
+++ b/site/feeds.js
@@ -128,7 +128,7 @@ const feedsMakers = [
           }
         `,
         output: lang === 'fr' ? '/seminaire.feed.xml' : '/seminar.feed.xml',
-        title: lang === 'fr' ? 'Actualités du séminaire médialab Sciences Po' : 'News from médialab SciencesPo\'s seminar',
+        title: lang === 'fr' ? 'Programme du séminaire médialab Sciences Po' : 'Program of the médialab SciencesPo\'s seminar',
     }),
     /**
      * Productions feeds maker
@@ -238,7 +238,7 @@ const feedsMakers = [
                 date: edge.node.lastUpdated,
                 url: edge.node.permalink[lang],
                 guid: edge.node.id,
-                custom_elements: [{ 'content:encoded': languageFallback(edge.node.description, lang) }],
+                custom_elements: [{ 'content:encoded': languageFallback(edge.node.content, lang) }],
               })
             }),
         ]
@@ -267,6 +267,10 @@ const feedsMakers = [
                   fr
                 }
                 permalink {
+                  en
+                  fr
+                }
+                content {
                   en
                   fr
                 }

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,3 +1,5 @@
+const feeds = require('./feeds.js');
+
 const GOOGLE_ANALYTICS_ID = process.env.GOOGLE_ANALYTICS_ID;
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -16,7 +18,23 @@ const plugins = [
     }
   },
   'gatsby-plugin-offline',
-  'gatsby-plugin-sitemap'
+  'gatsby-plugin-sitemap',
+  {
+    resolve: `gatsby-plugin-feed`,
+    options: {
+      query: `
+        {
+          site {
+            siteMetadata {
+              title
+              siteUrl
+            }
+          }
+        }
+      `,
+      feeds,
+    },
+  },
 ];
 
 if (NODE_ENV === 'production' && GOOGLE_ANALYTICS_ID)
@@ -32,7 +50,7 @@ if (NODE_ENV === 'production' && GOOGLE_ANALYTICS_ID)
 module.exports = {
   siteMetadata: {
     title: 'médialab Sciences Po',
-    siteUrl: 'https://medialab.sciencespo.fr'
+    siteUrl: 'https://medialab.sciencespo.fr', 
   },
   plugins
 };

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7102,6 +7102,30 @@
         }
       }
     },
+    "gatsby-plugin-feed": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.6.tgz",
+      "integrity": "sha512-iBywR85MF6zJ13wH45L5wKwkruwTQNG5CXoSeL8gMRZJvYRhTsoMTihK9YDVEemct1vRtZmzDWabSBGsKuNlZQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@hapi/joi": "^15.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.merge": "^4.6.2",
+        "rss": "^1.2.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-google-analytics": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.4.tgz",
@@ -9694,6 +9718,11 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -13059,6 +13088,30 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
       }
     },
     "run-async": {
@@ -17360,6 +17413,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml2js": {
       "version": "0.4.17",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
     "date-fns": "^2.0.0-alpha.27",
     "fs-extra": "^8.1.0",
     "gatsby": "^2.13.41",
+    "gatsby-plugin-feed": "^2.3.6",
     "gatsby-plugin-google-analytics": "^2.1.4",
     "gatsby-plugin-manifest": "^2.2.4",
     "gatsby-plugin-offline": "^2.2.4",


### PR DESCRIPTION
Cette PR est dédiée à l'ajout de flux RSS sur le site. Testée et fonctionnelle avec des outils de lecture de flux comme Feedbro.

#396 #397 

Le `build` génère dans les deux langues les flux suivants à la racine du site :

* toutes les news
* programme des séances du séminaire de recherche
* toutes les productions
* création ou modification de tout objet (#396)

Les flux excluent les objets en draft et utilisent un langageFallback pour afficher titre, description et contenu dans chaque langue. Ils sont limités à 50 items.

La PR ne gère pas les modifs éventuelles nécessaires pour prendre en charge la redirection depuis l'ancien site.