### PR TITLE
Remplacement du contenu manquant dans une langue (#392)

### DIFF
--- a/site/src/assets/scss/common/_body.scss
+++ b/site/src/assets/scss/common/_body.scss
@@ -233,3 +233,7 @@ span.tip:hover {
 .opacity {
   color: lightgrey;
 }
+
+.html-fallback-active{
+  opacity: .5;
+}

--- a/site/src/components/details/ActivityDetail.js
+++ b/site/src/components/details/ActivityDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {graphql} from 'gatsby';
-import RawHtml from '../helpers/RawHtml.js';
+import HtmlFallback from '../helpers/HtmlFallback.js';
 import {Link} from 'gatsby';
 
 import {I18N_MODEL} from '../../i18n.js';
@@ -232,7 +232,13 @@ export default function ActivityDetail({lang, activity, siteUrl}) {
           <hgroup>
             <h1 data-level-2="title" itemProp="name">{activity.name}</h1>
             <h2 data-level-2="baseline">{activity.baseline && <LanguageFallback lang={lang} translatedAttribute={activity.baseline} />}</h2>
-            <h3 data-level-3="description" itemProp="description"><RawHtml html={activity.description && activity.description[lang]} /></h3>
+            <HtmlFallback 
+              Tag="h3" 
+              data-level-3="description" 
+              itemProp="description" 
+              content={activity.description} 
+              lang={lang}
+            />
           </hgroup>
           <div className="details">
             <p className="type-objet"><span data-icon="activite" /> {I18N_TYPE_LABELS.activities[lang][activity.type]}</p>
@@ -247,10 +253,7 @@ export default function ActivityDetail({lang, activity, siteUrl}) {
             <Attachments attachments={activity.attachments} lang={lang} />
           </div>
 
-
-          <div className="article-contenu">
-            {activity.content && (activity.content[lang] && <RawHtml html={activity.content[lang]} />)}
-          </div>
+          <HtmlFallback lang={lang} content={activity.content} className="article-contenu" />
         </div>
 
       </article>

--- a/site/src/components/details/ActivityDetail.js
+++ b/site/src/components/details/ActivityDetail.js
@@ -228,12 +228,11 @@ export default function ActivityDetail({lang, activity, siteUrl}) {
         {/* Toggle Langue */}
         <ToggleLang lang={lang} content={activity.content} />
 
-        {/* FR */}
-        <div className="block-lang fr" lang="fr">
+        <div className={`"block-lang ${lang}`} lang={lang}>
           <hgroup>
             <h1 data-level-2="title" itemProp="name">{activity.name}</h1>
             <h2 data-level-2="baseline">{activity.baseline && <LanguageFallback lang={lang} translatedAttribute={activity.baseline} />}</h2>
-            <h3 data-level-3="description" itemProp="description"><RawHtml html={activity.description && activity.description.fr} /></h3>
+            <h3 data-level-3="description" itemProp="description"><RawHtml html={activity.description && activity.description[lang]} /></h3>
           </hgroup>
           <div className="details">
             <p className="type-objet"><span data-icon="activite" /> {I18N_TYPE_LABELS.activities[lang][activity.type]}</p>
@@ -243,34 +242,14 @@ export default function ActivityDetail({lang, activity, siteUrl}) {
               endDateSchemaProp={'dissolutionDate'}
               startDate={activity.startDate}
               endDate={activity.endDate}
-              lang="fr" />
+              lang={lang} />
             <TimeNews startDate={activity.startDate} endDate={activity.endDate} />
-            <Attachments attachments={activity.attachments} lang="fr" />
+            <Attachments attachments={activity.attachments} lang={lang} />
           </div>
 
 
           <div className="article-contenu">
-            {activity.content && (activity.content.fr && <RawHtml html={activity.content.fr} />)}
-          </div>
-        </div>
-
-        {/* EN */}
-        <div className="block-lang en" lang="en">
-          <hgroup>
-            <h1 data-level-2="title">{activity.name}</h1>
-            <h2 data-level-2="baseline">{activity.baseline && <LanguageFallback lang={lang} translatedAttribute={activity.baseline} />}</h2>
-            <h3 data-level-3="description"><RawHtml html={activity.description && activity.description.en} /></h3>
-          </hgroup>
-          <div className="details">
-            <p className="type-objet"><span data-icon="activite" /> {I18N_TYPE_LABELS.activities[lang][activity.type]}</p>
-            <DateNews
-              isTimeSpan startDate={activity.startDate} endDate={activity.endDate}
-              lang="en" />
-            <TimeNews startDate={activity.startDate} endDate={activity.endDate} />
-            <Attachments attachments={activity.attachments} lang="en" />
-          </div>
-          <div className="article-contenu">
-            {activity.content && (activity.content.en && <RawHtml html={activity.content.en} />)}
+            {activity.content && (activity.content[lang] && <RawHtml html={activity.content[lang]} />)}
           </div>
         </div>
 

--- a/site/src/components/details/NewsDetail.js
+++ b/site/src/components/details/NewsDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {graphql} from 'gatsby';
-import RawHtml from '../helpers/RawHtml.js';
+import HtmlFallback from '../helpers/HtmlFallback.js';
 import {Link} from 'gatsby';
 
 import ToggleLang from './fragments/ToggleLang.js';
@@ -224,7 +224,7 @@ export default function NewsDetail({lang, news, siteUrl}) {
           <div className={`block-lang ${lang}`} lang={lang}>
             <hgroup>
               <h1 data-type="title"> <LanguageFallback lang={lang} translatedAttribute={news.title} /></h1>
-              <h2 data-type="description"><RawHtml html={news.description && (news.description[lang])} /></h2>
+              <HtmlFallback Tag="h2" data-type="description" content={news.description} lang={lang} />
             </hgroup>
             <div className="details">
               <p className="type-objet">
@@ -246,9 +246,7 @@ export default function NewsDetail({lang, news, siteUrl}) {
               )}
               <Attachments attachments={news.attachments} lang={lang} />
             </div>
-            <div className="article-contenu">
-              {news.content && (news.content[lang] && <RawHtml html={news.content[lang]} />)}
-            </div>
+            <HtmlFallback lang={lang} content={news.content} className="article-contenu" />
           </div>
         </article>
 

--- a/site/src/components/details/NewsDetail.js
+++ b/site/src/components/details/NewsDetail.js
@@ -221,19 +221,18 @@ export default function NewsDetail({lang, news, siteUrl}) {
           {/* Toggle Langue */}
           <ToggleLang lang={lang} content={news.content} />
 
-          {/* FR */}
-          <div className="block-lang fr" lang="fr">
+          <div className={`block-lang ${lang}`} lang={lang}>
             <hgroup>
               <h1 data-type="title"> <LanguageFallback lang={lang} translatedAttribute={news.title} /></h1>
-              <h2 data-type="description"><RawHtml html={news.description && (news.description.fr)} /></h2>
+              <h2 data-type="description"><RawHtml html={news.description && (news.description[lang])} /></h2>
             </hgroup>
             <div className="details">
               <p className="type-objet">
                 <span data-icon="news" />
                 <span className="type-news">{I18N_TYPE_LABELS.news[lang][news.type]}</span>
-                {news.label && news.label.fr ? <span>, {news.label.fr}</span> : ''}
+                {news.label && news.label[lang] ? <span>, {news.label[lang]}</span> : ''}
               </p>
-              <DateNews startDate={news.startDate} endDate={news.endDate} lang="fr" />
+              <DateNews startDate={news.startDate} endDate={news.endDate} lang={lang} />
               <TimeNews startDate={news.startDate} endDate={news.endDate} />
               {news.place && (
                 <p
@@ -245,41 +244,10 @@ export default function NewsDetail({lang, news, siteUrl}) {
                   <span itemProp="address">{news.place}</span>
                 </p>
               )}
-              <Attachments attachments={news.attachments} lang="fr" />
+              <Attachments attachments={news.attachments} lang={lang} />
             </div>
             <div className="article-contenu">
-              {news.content && (news.content.fr && <RawHtml html={news.content.fr} />)}
-            </div>
-          </div>
-
-          {/* Chapô EN */}
-          <div className="block-lang en" lang="en">
-            <hgroup>
-              <h1 data-type="title"><LanguageFallback lang={lang} translatedAttribute={news.title} /></h1>
-              <h2 data-type="description"><RawHtml html={news.description && (news.description.en)} /></h2>
-            </hgroup>
-            <div className="details">
-              <p className="type-objet">
-                <span data-icon="news" />
-                <span className="type-news">{I18N_TYPE_LABELS.news[lang][news.type]}</span>
-                {news.label && news.label.en && <span>, {news.label.en}</span>}
-              </p>
-              <DateNews startDate={news.startDate} endDate={news.endDate} lang="en" />
-              <TimeNews startDate={news.startDate} endDate={news.endDate} />
-              {news.place && (
-                <p
-                  className="place"
-                  itemProp="location"
-                  itemScope
-                  itemType="https://schema.org/Place"
-                  aria-label={i18n[lang].place}>
-                  <span itemProp="address">{news.place}</span>
-                </p>
-              )}
-              <Attachments attachments={news.attachments} lang="en" />
-            </div>
-            <div className="article-contenu">
-              {news.content && (news.content.en && <RawHtml html={news.content.en} />)}
+              {news.content && (news.content[lang] && <RawHtml html={news.content[lang]} />)}
             </div>
           </div>
         </article>

--- a/site/src/components/details/PeopleDetail.js
+++ b/site/src/components/details/PeopleDetail.js
@@ -430,23 +430,14 @@ export default function PeopleDetail({lang, person, siteUrl}) {
               {/* Toggle Langue */}
               <ToggleLang lang={lang} content={person.bio} />
 
-              {/* FR */}
               <div
                 itemProp="description"
-                className="biographie-content block-lang fr"
-                lang="fr"
+                className={`biographie-content block-lang ${lang}`}
+                lang={lang}
                 aria-label="Biographie" >
-                {person.bio && person.bio.fr ? <RawHtml html={person.bio.fr} /> : null}
+                {person.bio && person.bio[lang] ? <RawHtml html={person.bio[lang]} /> : null}
               </div>
 
-              {/* EN */}
-              <div
-                itemProp="description"
-                className="biographie-content block-lang en"
-                lang="en"
-                aria-label="Biography" >
-                {person.bio && person.bio.en ? <RawHtml html={person.bio.en} /> : null}
-              </div>
             </div>
 
             <Highlights people={person} lang={lang} />

--- a/site/src/components/details/PeopleDetail.js
+++ b/site/src/components/details/PeopleDetail.js
@@ -13,7 +13,7 @@ import RelatedNews from './fragments/RelatedNews.js';
 
 import Nav from '../common/Nav.js';
 
-import RawHtml from '../helpers/RawHtml';
+import HtmlFallback from '../helpers/HtmlFallback';
 import {templateMembership} from '../helpers/helpers.js';
 import PageMeta from '../helpers/PageMeta.js';
 
@@ -435,7 +435,7 @@ export default function PeopleDetail({lang, person, siteUrl}) {
                 className={`biographie-content block-lang ${lang}`}
                 lang={lang}
                 aria-label="Biographie" >
-                {person.bio && person.bio[lang] ? <RawHtml html={person.bio[lang]} /> : null}
+                <HtmlFallback lang={lang} content={person.bio} />
               </div>
 
             </div>

--- a/site/src/components/details/ProductionDetail.js
+++ b/site/src/components/details/ProductionDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {graphql} from 'gatsby';
-import RawHtml from '../helpers/RawHtml.js';
+import HtmlFallback from '../helpers/HtmlFallback.js';
 import DateNews from '../helpers/DateNews.js';
 import {Link} from 'gatsby';
 
@@ -116,7 +116,7 @@ const mainPermalink = {
 const LangBlock = ({production, lang}) => {
   let ref = (
     <p itemProp="description" className="p-ref">
-      {production.description && <RawHtml html={production.description[lang]} />}
+      <HtmlFallback lang={lang} content={production.description} />
       {production.url && <br /> } {production.url ? production.url + ' ⤤' : ''}
     </p>
   );
@@ -148,9 +148,12 @@ const LangBlock = ({production, lang}) => {
         <DateNews startDateSchemaProp="datePublished" startDate={production.date} lang={lang} />
         {ref}
       </div>
-      <div className="article-contenu" itemProp="headline">
-        {production.content && (production.content[lang] && <RawHtml html={production.content[lang]} />)}
-      </div>
+      <HtmlFallback 
+        lang={lang} 
+        content={production.content} 
+        className="article-contenu" 
+        itemProp="headline" 
+      />
     </div>
   );
 };

--- a/site/src/components/details/ProductionDetail.js
+++ b/site/src/components/details/ProductionDetail.js
@@ -249,10 +249,7 @@ export default function ProductionDetail({lang, production, siteUrl}) {
           <ToggleLang lang={lang} content={production.content} />
 
           {/* FR */}
-          <LangBlock production={production} lang="fr" />
-
-          {/* EN */}
-          <LangBlock production={production} lang="en" />
+          <LangBlock production={production} lang={lang} />
         </article>
 
         <aside id="all-aside">

--- a/site/src/components/details/fragments/ToggleLang.js
+++ b/site/src/components/details/fragments/ToggleLang.js
@@ -2,6 +2,10 @@ import React from 'react';
 
 export default function ToggleLang({lang, content}) {
 
+  if (!content[lang] || !content[lang].length) {
+    return null;
+  }
+
   const enoughContentLength = 1500;
 
   const isEnEnough = content.en && content.en.length >= enoughContentLength;

--- a/site/src/components/helpers/HtmlFallback.js
+++ b/site/src/components/helpers/HtmlFallback.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import RawHtml from './RawHtml';
+
+const message = {
+    fr: '⚐ Cet article est disponible uniquement en anglais.',
+    en: '⚐ This article is available only in french.'
+};
+
+export default function HtmlFallback({
+    content = {},
+    lang = 'en',
+    Tag = 'div',
+    ...props
+}) {
+  let isAFallback;
+  let actualContent;
+  const otherLang = lang === 'fr' ? 'en' : 'fr';
+
+  if (content && content[lang] && content[lang].length) {
+    actualContent = content[lang];
+  }
+  else if (content && content[otherLang]) {
+      isAFallback = true;
+      actualContent = content[otherLang];
+  }
+  else return null;
+
+  return (
+    <Tag {...props} className={`${isAFallback ? 'html-fallback-active' : 'html-fallback'} ${props.className ? props.className : ''}`}>
+        {actualContent && <RawHtml html={actualContent} />}
+    </Tag>
+  );
+}

--- a/site/src/components/helpers/HtmlFallback.js
+++ b/site/src/components/helpers/HtmlFallback.js
@@ -2,11 +2,6 @@ import React from 'react';
 
 import RawHtml from './RawHtml';
 
-const message = {
-    fr: '⚐ Cet article est disponible uniquement en anglais.',
-    en: '⚐ This article is available only in french.'
-};
-
 export default function HtmlFallback({
     content = {},
     lang = 'en',


### PR DESCRIPTION
Cette PR apporte les améliorations suivantes :

* un peu de refacto de la gestion des contenus localisés dans le react (suppression de doublons de code à cause de la langue)
* implémentation d'un `HtmlFallback` qui affiche le contenu dans l'autre langue avec opacité 0.5 si le contenu de la langue choisie n'est pas du tout disponible. Dans ce cas le `toggleLanguage` n'est pas affiché.

En l'état il est appliqué sur tous les endroits des pages détail contenant auparavant un `RawHtml` soit :

* page production - `description` et `content`
* page people - `bio`
* page activité - `description` et `content`
* page news - `description` et `content`