### PR TITLE
use specific url for tool page  #498

### DIFF
--- a/site/components/details/ToolDetail.js
+++ b/site/components/details/ToolDetail.js
@@ -31,8 +31,8 @@ const i18n = {
 };
 
 const mainPermalink = {
-  fr: '/productions',
-  en: '/en/productions'
+  fr: '/outils',
+  en: '/en/tools'
 };
 
 const LangBlock = ({tool, lang, dateYear, usagesText}) => {

--- a/wilson/reducers.js
+++ b/wilson/reducers.js
@@ -110,13 +110,18 @@ exports.productions = function reduceProductions(pathPrefix, production) {
   const content = template(pathPrefix, production.content);
   const slug = last(production.slugs);
 
+  let permalinkBase = permalinks.productions;
+  if (['code', 'software'].includes(production.type)) {
+    permalinkBase = permalinks.tools;
+  }
+
   return {
     ...production,
     content,
     attachments: resolveAttachments(pathPrefix, production.attachments || []),
     permalink: {
-      fr: `${permalinks.productions.fr}/${slug}`,
-      en: `${permalinks.productions.en}/${slug}`
+      fr: `${permalinkBase.fr}/${slug}`,
+      en: `${permalinkBase.en}/${slug}`
     }
   };
 };


### PR DESCRIPTION
This PR addresses https://github.com/medialab/website/issues/498 : changing tools object pages URLs to `en/tools/:slug` and `/outils/:slug`. For that matter it adds an exception in the [productions permalink reducer](https://github.com/medialab/website/blob/tools-new-urls/wilson/reducers.js#L113) and updates the tools objet's page mainPage from productions to tools to have "tools" highlighted.

@Yomguithereal could you just double-check it will not create a mess in terms of routing ?